### PR TITLE
Adds support for end-line comments

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -20,6 +20,7 @@ const (
 	prefixCookware         = '#'
 	prefixTimer            = '~'
 	prefixBlockComment     = '['
+	prefixInlineComment    = '-'
 )
 
 // Cookware represents a cookware item
@@ -233,10 +234,22 @@ func parseRecipe(line string) (*Step, error) {
 				continue
 			}
 		}
+		if ch == prefixInlineComment {
+			nextRune := peek(line[index+1:])
+			if nextRune == prefixInlineComment {
+				// end-line comment ahead
+				comment = strings.TrimSpace(line[index+len(commentsLinePrefix):])
+				if err != nil {
+					return nil, err
+				}
+				step.Comments = append(step.Comments, comment)
+				break
+			}
+		}
 		// raw string
 		directions.WriteRune(ch)
 	}
-	step.Directions = directions.String()
+	step.Directions = strings.TrimSpace(directions.String())
 	return &step, nil
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -13,6 +13,35 @@ func TestParseString(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			"Works with inline comments",
+			`-- Don't burn the roux!
+
+			Mash @potato{2%kg} until smooth -- alternatively, boil 'em first, then mash 'em, then stick 'em in a stew.`,
+			&Recipe{
+				Steps: []Step{
+					{
+						Comments: []string{
+							"Don't burn the roux!",
+						},
+					},
+					{
+						Ingredients: []Ingredient{
+							{
+								Name:   "potato",
+								Amount: IngredientAmount{true, 2.0, "2", "kg"},
+							},
+						},
+						Timers:     []Timer{},
+						Cookware:   []Cookware{},
+						Directions: "Mash potato until smooth",
+						Comments:   []string{"alternatively, boil 'em first, then mash 'em, then stick 'em in a stew."},
+					},
+				},
+				Metadata: make(Metadata),
+			},
+			false,
+		},
+		{
 			"Empty string returns an error",
 			"",
 			nil,


### PR DESCRIPTION
In

```
Mash @potato{2%kg} until smooth -- alternatively, boil 'em first, then mash 'em, then stick 'em in a stew.
```

identifies `alternatively, boil 'em first, then mash 'em, then stick 'em in a stew.` as a comment.