### PR TITLE
Changes test fail to show the struct insted of the string representation

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -247,7 +247,7 @@ Put in an #oven for ~{4%minutes}.`,
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("ParseString() = %+v, want %+v", got, tt.want)
+				t.Errorf("ParseString() = %#v, want %#v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
https://pkg.go.dev/fmt#hdr-Printing
```
%#v	a Go-syntax representation of the value
```