### PR TITLE
Parse metadata in front matter and test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,10 @@ module github.com/aquilax/cooklang-go
 
 go 1.22.2
 
+require github.com/stretchr/testify v1.9.0
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.9.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,12 @@ module github.com/aquilax/cooklang-go
 
 go 1.22.2
 
-require github.com/stretchr/testify v1.9.0
+require (
+	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/parser.go
+++ b/parser.go
@@ -188,6 +188,7 @@ type RecipeV2 struct {
 type ParserV2 struct {
 	config        *ParseV2Config
 	inFrontMatter bool
+	pastFirstLine bool
 	frontMatter   strings.Builder
 }
 
@@ -326,7 +327,7 @@ func (p *ParserV2) parseLine(line string, recipe *RecipeV2) error {
 	// header/footer
 	rightTrimmedLine := strings.TrimRight(line, " ")
 
-	if rightTrimmedLine == "---" && !p.inFrontMatter {
+	if !p.pastFirstLine && rightTrimmedLine == "---" && !p.inFrontMatter {
 		p.inFrontMatter = true
 	} else if rightTrimmedLine == "---" && p.inFrontMatter {
 		p.inFrontMatter = false
@@ -359,6 +360,7 @@ func (p *ParserV2) parseLine(line string, recipe *RecipeV2) error {
 		}
 		recipe.Steps = append(recipe.Steps, *step)
 	}
+	p.pastFirstLine = true
 	return nil
 }
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,6 +2,7 @@ package cooklang
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -357,5 +358,78 @@ func Test_getTimer(t *testing.T) {
 				t.Errorf("getTimer() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFrontMatter(t *testing.T) {
+	in := `---   
+title: food dish
+tags:
+  - vegan
+  - vegetarian
+  - delicious
+--- 
+
+Mash @banana{1%large} and eat it.`
+
+	r, err := NewParserV2(&ParseV2Config{}).ParseString(in)
+	if err != nil {
+		t.Error(err)
+		t.FailNow()
+	} else {
+		if len(r.Steps) != 1 {
+			t.Errorf("wrong steps - expected 1 got %d", len(r.Steps))
+		} else {
+
+		}
+		if len(r.Metadata) != 2 {
+			t.Errorf("wrong metadata - expected 2 got %d", len(r.Metadata))
+		} else {
+			if r.Metadata["title"] != "food dish" {
+				t.Error("wrong title")
+			}
+			t.Logf("%T => %#v", r.Metadata["tags"], r.Metadata["tags"])
+			if tags, ok := r.Metadata["tags"]; ok {
+				if tagsArray, ok := tags.([]any); ok {
+					if len(tagsArray) != 3 {
+						t.Errorf("wrong number of tags - expected 3 got %d", len(tagsArray))
+					} else {
+						if tagsArray[0] != "vegan" {
+							t.Error("0 index tag wrong")
+						}
+						if tagsArray[1] != "vegetarian" {
+							t.Error("1 index tag wrong")
+						}
+						if tagsArray[2] != "delicious" {
+							t.Error("2 index tag wrong")
+						}
+					}
+				} else {
+					t.Error("not right type for tags")
+				}
+			} else {
+				t.Error("tags field missing")
+			}
+		}
+	}
+}
+
+func TestBadFrontMatter(t *testing.T) {
+	in := `---   
+title: food dish
+invalid yaml :-)
+--- 
+
+Mash @banana{1%large} and eat it.`
+
+	_, err := NewParserV2(&ParseV2Config{}).ParseString(in)
+	if err == nil {
+		t.Error("expected parsing error")
+		t.FailNow()
+	} else {
+		exp := "decoding yaml front matter"
+		if !strings.Contains(err.Error(), exp) {
+			t.Errorf("wrong error, expected '%s' got '%s'", exp, err.Error())
+		}
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -433,3 +433,24 @@ Mash @banana{1%large} and eat it.`
 		}
 	}
 }
+
+func TestBadFrontMatterNotAtTop(t *testing.T) {
+	in := `
+Cook and mash @potato.
+
+---
+title: food dish
+---
+
+Mash @banana{1%large} and eat it.`
+
+	r, err := NewParserV2(&ParseV2Config{}).ParseString(in)
+	if err != nil {
+		t.Error("unexpected parsing error")
+		t.FailNow()
+	} else {
+		if len(r.Metadata) != 0 {
+			t.Error("got metadata when expected none")
+		}
+	}
+}


### PR DESCRIPTION
This adds support for metadata being encoded as YAML and within front matter at the top of the .cook file.

It changes the Metadata type to be map[string]any so as to support things like "tags" being an array of items (and to be compatible with the YAML decoder). This is a minor compatibility breakage, but it seems like a better fit. https://cooklang.org/docs/spec/#metadata specifically says it is YAML, which should allow different datatypes and nested structs.

